### PR TITLE
prevent update with same resource version being handled

### DIFF
--- a/eventloop_test.go
+++ b/eventloop_test.go
@@ -1,0 +1,19 @@
+package kubehandler
+
+import (
+	"testing"
+
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_resourceVersion(t *testing.T) {
+	var route interface{}
+	route = routev1.Route{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "test"}}
+	assert.NotNil(t, route)
+
+	version, ok := resourceVersion(route)
+	assert.True(t, ok)
+	assert.Equal(t, "test", version)
+}


### PR DESCRIPTION
Hi 
I like your kubehandler very much. It makes my controller much easier.
But I had one problem with it. I go update events where the resource version of the udated object was the same. According to the kubernetes sample controller this is known to be so. See https://github.com/kubernetes/sample-controller/blob/f3ae960ce1a1699d6f4e6486247074fe3346048e/controller.go#L136

Since I didn't find an interface on the kubernetes objects to provide the resource version I implemented some reflection logic to get the resource version of objects with default layout.

Perhaps this is of any use for you too.

Regards

Marc